### PR TITLE
Fixed server close issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utp",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "repository": "git://github.com/mafintosh/utp",
   "description": "utp (micro transport protocol) implementation in node",
   "dependencies": {


### PR DESCRIPTION
The stream `close` event was not getting emitted when calling `.end()` therefore I switched it to `.destroy()` which was added in Node v8. Also added a fail safe when there are no connections.